### PR TITLE
fix: #18 未使用PrismaClientの削除とルートパラメータ名の統一

### DIFF
--- a/backend/controller/tasksController.js
+++ b/backend/controller/tasksController.js
@@ -16,7 +16,7 @@ const getAllTasks = async (req, res) => {
 };
 
 const getTaskById = async (req, res) => {
-  const { taskId } = req.params;
+  const taskId = req.params.id;
   logger.info(`🔍 getTaskById: Fetching task with ID: ${taskId}`);
 
   try {
@@ -97,7 +97,7 @@ const createTask = async (req, res) => {
 };
 
 const updateTask = async (req, res) => {
-  const { taskId } = req.params;
+  const taskId = req.params.id;
   logger.info(`updateTask: Starting to update task with ID: ${taskId}`);
   logger.info('Request body:', JSON.stringify(req.body, null, 2));
 
@@ -157,7 +157,7 @@ const updateTask = async (req, res) => {
 };
 
 const deleteTask = async (req, res) => {
-  const { taskId } = req.params;
+  const taskId = req.params.id;
   logger.info(`deleteTask: Starting to delete task with ID: ${taskId}`);
 
   try {

--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -1,8 +1,6 @@
 const { verifyToken } = require('../utils/jwt');
 const { sendErrorResponse } = require('../utils/response');
-const { PrismaClient } = require('@prisma/client');
 const { HTTP_STATUS, ERROR_MESSAGES } = require('../utils/constants');
-const prisma = new PrismaClient();
 
 const authenticateToken = async (req, res, next) => {
   try {

--- a/backend/routers/studyHistoriesRouter.js
+++ b/backend/routers/studyHistoriesRouter.js
@@ -14,10 +14,10 @@ const router = express.Router();
 
 router.get('/', authenticateToken, getAllHistories);
 router.post('/', authenticateToken, createHistory);
-router.get('/:historyId', authenticateToken, getHistory);
-router.put('/:historyId', authenticateToken, updateHistory);
-router.delete('/:historyId', authenticateToken, deleteHistory);
+router.get('/:id', authenticateToken, getHistory);
+router.put('/:id', authenticateToken, updateHistory);
+router.delete('/:id', authenticateToken, deleteHistory);
 router.post('/start', authenticateToken, startStudyHistory);
-router.put('/:historyId/end', authenticateToken, endStudyHistory);
+router.put('/:id/end', authenticateToken, endStudyHistory);
 
 module.exports = router;

--- a/backend/routers/tasksRouter.js
+++ b/backend/routers/tasksRouter.js
@@ -5,9 +5,9 @@ const { getAllTasks, getTaskById, createTask, updateTask, deleteTask } = require
 const router = express.Router();
 
 router.get('/', authenticateToken, getAllTasks);
-router.get('/:taskId', authenticateToken, getTaskById);
+router.get('/:id', authenticateToken, getTaskById);
 router.post('/', authenticateToken, createTask);
-router.put('/:taskId', authenticateToken, updateTask);
-router.delete('/:taskId', authenticateToken, deleteTask);
+router.put('/:id', authenticateToken, updateTask);
+router.delete('/:id', authenticateToken, deleteTask);
 
 module.exports = router;

--- a/backend/tests/tasks.test.js
+++ b/backend/tests/tasks.test.js
@@ -13,7 +13,7 @@ describe('Tasks API', () => {
     });
   });
 
-  describe('GET /tasks/:taskId', () => {
+  describe('GET /tasks/:id', () => {
     it('should return a specific task', async () => {
       const res = await request(app)
         .get('/tasks/1')


### PR DESCRIPTION
- middleware/auth.js: 未使用のPrismaClientインポートと初期化を削除
- routers/tasksRouter.js: ルートパラメータを :taskId から :id に統一
- routers/studyHistoriesRouter.js: ルートパラメータを :historyId から :id に統一（controllerとの不整合バグを修正）
- controller/tasksController.js: req.params.taskId → req.params.id に対応
- tests/tasks.test.js: describeテキストを :taskId → :id に更新