### PR TITLE
feat: 本番用APIエンドポイント設定の整備 (#45)

### DIFF
--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -1,0 +1,2 @@
+# 開発環境用API設定
+VITE_API_BASE_URL=http://localhost:3000

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,4 @@
+# バックエンドAPIのベースURL
+# 開発環境: http://localhost:3000
+# 本番環境: https://xxxxxxxx.execute-api.ap-northeast-1.amazonaws.com/prod
+VITE_API_BASE_URL=http://localhost:3000

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,0 +1,3 @@
+# 本番環境用API設定
+# AWS API Gateway のエンドポイントに変更してください
+VITE_API_BASE_URL=https://xxxxxxxx.execute-api.ap-northeast-1.amazonaws.com/prod

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,3 +1,4 @@
 # 本番環境用API設定
 # AWS API Gateway のエンドポイントに変更してください
-VITE_API_BASE_URL=https://xxxxxxxx.execute-api.ap-northeast-1.amazonaws.com/prod
+# 実際の値はデプロイ環境で注入するか、ビルド前に設定してください
+VITE_API_BASE_URL=

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,0 +1,30 @@
+import axios from 'axios'
+
+const apiClient = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE_URL || 'http://localhost:3000',
+  headers: {
+    'Content-Type': 'application/json',
+  },
+})
+
+// リクエストインターセプター（認証トークン付与）
+apiClient.interceptors.request.use((config) => {
+  const token = localStorage.getItem('token')
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`
+  }
+  return config
+})
+
+// レスポンスインターセプター（エラーハンドリング）
+apiClient.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    if (error.response?.status === 401) {
+      localStorage.removeItem('token')
+    }
+    return Promise.reject(error)
+  },
+)
+
+export default apiClient

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,30 +1,51 @@
-import axios from 'axios'
+import axios, { AxiosHeaders, type InternalAxiosRequestConfig } from 'axios'
+
+const baseURL = import.meta.env.VITE_API_BASE_URL
+
+if (!baseURL) {
+  throw new Error('VITE_API_BASE_URL is not set')
+}
 
 const apiClient = axios.create({
-  baseURL: import.meta.env.VITE_API_BASE_URL || 'http://localhost:3000',
+  baseURL,
   headers: {
     'Content-Type': 'application/json',
   },
 })
 
-// リクエストインターセプター（認証トークン付与）
-apiClient.interceptors.request.use((config) => {
+export const requestInterceptor = (config: InternalAxiosRequestConfig) => {
   const token = localStorage.getItem('token')
   if (token) {
-    config.headers.Authorization = `Bearer ${token}`
+    const headers = config.headers ?? {}
+    if (headers instanceof AxiosHeaders) {
+      headers.set('Authorization', `Bearer ${token}`)
+    } else {
+      ;(headers as Record<string, string>).Authorization = `Bearer ${token}`
+    }
+    config.headers = headers as InternalAxiosRequestConfig['headers']
   }
   return config
-})
+}
+
+export const responseErrorInterceptor = (error: unknown) => {
+  if (
+    error &&
+    typeof error === 'object' &&
+    'response' in error &&
+    (error as { response?: { status?: number } }).response?.status === 401
+  ) {
+    localStorage.removeItem('token')
+  }
+  return Promise.reject(error)
+}
+
+// リクエストインターセプター（認証トークン付与）
+apiClient.interceptors.request.use(requestInterceptor)
 
 // レスポンスインターセプター（エラーハンドリング）
 apiClient.interceptors.response.use(
   (response) => response,
-  (error) => {
-    if (error.response?.status === 401) {
-      localStorage.removeItem('token')
-    }
-    return Promise.reject(error)
-  },
+  responseErrorInterceptor,
 )
 
 export default apiClient


### PR DESCRIPTION
## 概要

フロントエンドのAPIエンドポイント設定を環境別に管理できるよう整備します。

## 変更内容

- `frontend/src/api/client.ts`: axiosインスタンスを作成し、`VITE_API_BASE_URL`環境変数を使用
  - リクエストインターセプター（JWTトークン自動付与）
  - レスポンスインターセプター（401エラー時のトークン削除）
- `frontend/.env.development`: 開発環境用APIエンドポイント設定（`http://localhost:3000`）
- `frontend/.env.production`: 本番環境用APIエンドポイント設定（API GatewayのURL）
- `frontend/.env.example`: 環境設定のテンプレート

## 関連Issue

Closes #45
