### PR TITLE
[backend] Lambda対応: serverless-expressの導入

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -1,0 +1,104 @@
+require('dotenv').config();
+const express = require('express');
+const mysql = require('mysql2');
+const path = require('path');
+const swaggerUi = require('swagger-ui-express');
+const YAML = require('yamljs');
+const logger = require('./utils/logger');
+
+// ルーティングを定義
+const taskRoutes = require('./routers/tasksRouter');
+const bookRoutes = require('./routers/booksRouter');
+const goalsRoutes = require('./routers/goalsRouter');
+const historyiesRoutes = require('./routers/studyHistoriesRouter');
+const userRoutes = require('./routers/userRouter');
+const authRoutes = require('./routers/authRouter');
+
+const app = express();
+// Prisma Client はモジュールスコープの単一インスタンス（prismaClient.js）を再利用する。
+// Lambda 実行コンテキストが再利用される限り、require キャッシュにより
+// このモジュールの初期化（DB接続確立含む）はコールドスタート時のみ発生する。
+const prisma = require('./prismaClient');
+
+// CORS設定
+app.use((req, res, next) => {
+  res.header('Access-Control-Allow-Origin', process.env.ALLOWED_ORIGIN || 'http://localhost:3000');
+  res.header('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE');
+  res.header('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+  next();
+});
+
+// ログミドルウェア
+app.use((req, res, next) => {
+  const timestamp = new Date().toISOString();
+  logger.info(`[${timestamp}] ${req.method} ${req.url}`);
+  next();
+});
+
+app.use(express.json());
+
+// mysql2 直接接続（既存機能踏襲。モジュールスコープで一度だけ生成し、
+// Lambda 実行コンテキスト間で再利用する）
+const db = mysql.createConnection({
+  host: process.env.BACKEND_DB_HOST || process.env.DB_HOST,
+  user: process.env.BACKEND_DB_USER || process.env.DB_USER,
+  password: process.env.BACKEND_DB_PASSWORD || process.env.DB_PASSWORD,
+  database: process.env.BACKEND_DB_NAME || process.env.DB_NAME,
+  port: process.env.BACKEND_DB_PORT || process.env.DB_PORT || 3306,
+});
+
+db.connect(err => {
+  if (err) {
+    logger.error('DB connection failed:', err);
+  } else {
+    logger.info('Connected to MySQL');
+  }
+});
+const swaggerDocument = YAML.load(path.join(__dirname, './document/OpenAPI/OpenAPI_v1.yaml'));
+
+app.use('/docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument, {
+  customCss: '.swagger-ui .topbar { display: none }',
+  customSiteTitle: 'Study Habit Management API',
+  customfavIcon: '/favicon.ico',
+  swaggerOptions: {
+    persistAuthorization: true,
+    displayRequestDuration: true,
+    tryItOutEnabled: true,
+  },
+}));
+
+// Health check endpoint（既存のルート設定の前に追加）
+app.get('/health', (req, res) => {
+  res.status(200).json({
+    status: 'OK',
+    timestamp: new Date().toISOString(),
+    environment: process.env.NODE_ENV || 'development',
+    version: '1.0.0',
+  });
+});
+
+app.use('/tasks',taskRoutes);
+app.use('/books',bookRoutes);
+app.use('/goals',goalsRoutes);
+app.use('/history',historyiesRoutes);
+app.use('/user',userRoutes);
+app.use('/auth',authRoutes);
+
+app.get('/', (req, res) => {
+  logger.info('Root endpoint accessed');
+  res.json({ message: 'Hello, Backend is running!', timestamp: new Date().toISOString() });
+});
+
+app.get('/users', async (req, res) => {
+  logger.info('Get users endpoint called');
+  try {
+    const users = await prisma.users.findMany();
+    logger.info(`✅ Found ${users.length} users`);
+    res.json({ status: 'success', data: users });
+  } catch (error) {
+    logger.error('❌ Error fetching users:', error);
+    res.status(500).json({ status: 'error', message: 'サーバーエラー' });
+  }
+});
+
+module.exports = app;

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,102 +1,18 @@
-require('dotenv').config();
-const express = require('express');
-const mysql = require('mysql2');
-const path = require('path');
-const swaggerUi = require('swagger-ui-express');
-const YAML = require('yamljs');
+// backend/index.js
+// ローカル開発用エントリーポイント。
+// アプリケーション定義は app.js に分離済み。
+// Lambda 環境（AWS_LAMBDA_FUNCTION_NAME が設定されている）では
+// app.listen() を呼ばず、lambda.js 経由で serverless-express が
+// リクエストをハンドリングする。
+const app = require('./app');
 const logger = require('./utils/logger');
 
-// ルーティングを定義
-const taskRoutes = require('./routers/tasksRouter');
-const bookRoutes = require('./routers/booksRouter');
-const goalsRoutes = require('./routers/goalsRouter');
-const historyiesRoutes = require('./routers/studyHistoriesRouter');
-const userRoutes = require('./routers/userRouter');
-const authRoutes = require('./routers/authRouter');
-
-const app = express();
 const port = process.env.BACKEND_PORT || process.env.PORT || 3000;
-const prisma = require('./prismaClient');
 
-// CORS設定
-app.use((req, res, next) => {
-  res.header('Access-Control-Allow-Origin', process.env.ALLOWED_ORIGIN || 'http://localhost:3000');
-  res.header('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE');
-  res.header('Access-Control-Allow-Headers', 'Content-Type');
-  next();
-});
-
-// ログミドルウェア
-app.use((req, res, next) => {
-  const timestamp = new Date().toISOString();
-  logger.info(`[${timestamp}] ${req.method} ${req.url}`);
-  next();
-});
-
-app.use(express.json());
-
-const db = mysql.createConnection({
-  host: process.env.BACKEND_DB_HOST || process.env.DB_HOST,
-  user: process.env.BACKEND_DB_USER || process.env.DB_USER,
-  password: process.env.BACKEND_DB_PASSWORD || process.env.DB_PASSWORD,
-  database: process.env.BACKEND_DB_NAME || process.env.DB_NAME,
-  port: process.env.BACKEND_DB_PORT || process.env.DB_PORT || 3306,
-});
-
-db.connect(err => {
-  if (err) {
-    logger.error('DB connection failed:', err);
-  } else {
-    logger.info('Connected to MySQL');
-  }
-});
-const swaggerDocument = YAML.load(path.join(__dirname, './document/OpenAPI/OpenAPI_v1.yaml'));
-
-app.use('/docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument, {
-  customCss: '.swagger-ui .topbar { display: none }',
-  customSiteTitle: 'Study Habit Management API',
-  customfavIcon: '/favicon.ico',
-  swaggerOptions: {
-    persistAuthorization: true,
-    displayRequestDuration: true,
-    tryItOutEnabled: true,
-  },
-}));
-
-// Health check endpoint（既存のルート設定の前に追加）
-app.get('/health', (req, res) => {
-  res.status(200).json({
-    status: 'OK',
-    timestamp: new Date().toISOString(),
-    environment: process.env.NODE_ENV || 'development',
-    version: '1.0.0',
+if (!process.env.AWS_LAMBDA_FUNCTION_NAME) {
+  app.listen(port, () => {
+    logger.info(`Server is running on http://localhost:${port}`);
   });
-});
+}
 
-app.use('/tasks',taskRoutes);
-app.use('/books',bookRoutes);
-app.use('/goals',goalsRoutes);
-app.use('/history',historyiesRoutes);
-app.use('/user',userRoutes);
-app.use('/auth',authRoutes);
-
-app.get('/', (req, res) => {
-  logger.info('Root endpoint accessed');
-  res.json({ message: 'Hello, Backend is running!', timestamp: new Date().toISOString() });
-});
-
-app.listen(port, () => {
-  logger.info(`Server is running on http://localhost:${port}`);
-});
-
-app.get('/users', async (req, res) => {
-  logger.info('Get users endpoint called');
-  try {
-    const users = await prisma.users.findMany();
-    logger.info(`✅ Found ${users.length} users`);
-    res.json({ status: 'success', data: users });
-  } catch (error) {
-    logger.error('❌ Error fetching users:', error);
-    res.status(500).json({ status: 'error', message: 'サーバーエラー' });
-  }
-});
+module.exports = app;

--- a/backend/lambda.js
+++ b/backend/lambda.js
@@ -1,0 +1,8 @@
+// backend/lambda.js
+// AWS Lambda エントリーポイント。
+// Express app（app.js）を @vendia/serverless-express でラップし、
+// API Gateway / Lambda Function URL 等のイベントを Express にブリッジする。
+const serverlessExpress = require('@vendia/serverless-express');
+const app = require('./app');
+
+exports.handler = serverlessExpress({ app });

--- a/backend/package.json
+++ b/backend/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "@prisma/client": "^6.6.0",
+    "@vendia/serverless-express": "^4.12.6",
     "bcryptjs": "^3.0.2",
     "dotenv": "^16.4.7",
     "express": "^4.21.2",


### PR DESCRIPTION
## Summary
- `backend/app.js` を新設: Expressアプリ定義を分離（`app.listen()`なし、`module.exports = app`）
- `backend/index.js`: ローカル開発用の薄いエントリーポイントに変更。`AWS_LAMBDA_FUNCTION_NAME`が未設定の場合のみ`app.listen()`、appを再export
- `backend/lambda.js` を新設: `@vendia/serverless-express`でappをラップしLambdaハンドラーとしてexport
- `app.js`作成時に#59のCORS Authorizationヘッダー修正（develop未マージ）が失われていたため、同じ修正をapp.js側にも適用済み

Closes #41

## Scope外
- 実AWS Lambdaリソースの作成・デプロイ（CDK側は別Issue）
- 実Lambda環境での動作検証（Lambda関数が未デプロイのため不可能。デプロイ後に別途検証）

## Test plan
- [x] `node index.js`（`AWS_LAMBDA_FUNCTION_NAME`未設定）でサーバーが従来通り起動することを確認
- [x] `AWS_LAMBDA_FUNCTION_NAME`設定時に`app.listen()`が呼ばれないことを確認
- [x] `npm test`: 個別テスト106件パス。2スイート失敗は`.env`未配置による`BACKEND_JWT_SECRET`未設定という既知の無関係な問題（[PR #74](https://github.com/taka727/study_habit_management/pull/74)で切り分け済み）
- [x] `npm run lint`: 0 errors（56 warningsは全て今回変更していない既存ファイル由来）
- [ ] 実Lambda環境でのエンドツーエンド動作確認（Lambda関数デプロイ後に実施）

## 補足で見つかった別課題（本PRのスコープ外）
`tests/tasks.test.js`は認証ミドルウェア導入後もAuthorizationヘッダーを送っておらず、実環境変数下では401で失敗する既存のテスト不備を確認しました。別Issue化を検討してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)