### PR TITLE
[frontend] TypeScript型定義の整備（types/）

### DIFF
--- a/frontend/src/api/mock/books.ts
+++ b/frontend/src/api/mock/books.ts
@@ -1,10 +1,6 @@
 // Reading.vue 用モックハンドラー (/books)
 
-export interface Book {
-  id: number
-  title: string
-  description: string | null
-}
+import type { ApiBookMutationResponse, ApiListResponse, ApiMessageResponse, ApiMockResponse, Book, BookFormPayload } from '@/types'
 
 const seed: Book[] = [
   { id: 1, title: 'JavaScript完全ガイド', description: 'JavaScriptの基礎から応用まで丁寧に解説' },
@@ -19,16 +15,18 @@ export function handleBooks(
   method: string,
   url: string,
   body?: unknown,
-): Record<string, unknown> | null {
+): ApiMockResponse | null {
   if (method === 'GET' && url === '/books') {
-    return { status: 'success', data: [...books] }
+    const response: ApiListResponse<Book> = { status: 'success', data: [...books] }
+    return response
   }
 
   if (method === 'POST' && url === '/books') {
-    const { title, description } = body as { title: string; description: string | null }
+    const { title, description } = body as BookFormPayload
     const book: Book = { id: nextId++, title, description: description ?? null }
     books.push(book)
-    return { status: 'success', book }
+    const response: ApiBookMutationResponse<Book> = { status: 'success', book }
+    return response
   }
 
   const idMatch = url.match(/^\/books\/(\d+)$/)
@@ -38,14 +36,16 @@ export function handleBooks(
     if (method === 'PUT') {
       const index = books.findIndex((b) => b.id === id)
       if (index === -1) return null
-      const { title, description } = body as { title: string; description: string | null }
+      const { title, description } = body as BookFormPayload
       books[index] = { id, title, description: description ?? null }
-      return { status: 'success', book: books[index] }
+      const response: ApiBookMutationResponse<Book> = { status: 'success', book: books[index] }
+      return response
     }
 
     if (method === 'DELETE') {
       books = books.filter((b) => b.id !== id)
-      return { status: 'success' }
+      const response: ApiMessageResponse = { status: 'success' }
+      return response
     }
   }
 

--- a/frontend/src/api/mock/goals.ts
+++ b/frontend/src/api/mock/goals.ts
@@ -1,11 +1,6 @@
 // Milestone.vue 用モックハンドラー (/goals)
 
-export interface Goal {
-  id: number
-  name: string
-  description: string | null
-  goal_deadline: string
-}
+import type { ApiGoalMutationResponse, ApiListResponse, ApiMessageResponse, ApiMockResponse, Goal, GoalFormPayload } from '@/types'
 
 const seed: Goal[] = [
   { id: 1, name: '英単語1000語達成', description: '基本英単語を1000語習得する', goal_deadline: '2024-10-31T00:00:00.000Z' },
@@ -20,16 +15,18 @@ export function handleGoals(
   method: string,
   url: string,
   body?: unknown,
-): Record<string, unknown> | null {
+): ApiMockResponse | null {
   if (method === 'GET' && url === '/goals') {
-    return { status: 'success', data: [...goals] }
+    const response: ApiListResponse<Goal> = { status: 'success', data: [...goals] }
+    return response
   }
 
   if (method === 'POST' && url === '/goals') {
-    const { name, description, goal_deadline } = body as Omit<Goal, 'id'>
+    const { name, description, goal_deadline } = body as GoalFormPayload
     const goal: Goal = { id: nextId++, name, description: description ?? null, goal_deadline }
     goals.push(goal)
-    return { status: 'success', Goal: goal }
+    const response: ApiGoalMutationResponse<Goal> = { status: 'success', Goal: goal }
+    return response
   }
 
   const idMatch = url.match(/^\/goals\/(\d+)$/)
@@ -39,16 +36,18 @@ export function handleGoals(
     if (method === 'PUT') {
       const index = goals.findIndex((g) => g.id === id)
       if (index === -1) return null
-      const { name, description, goal_deadline } = body as Partial<Goal>
+      const { name, description, goal_deadline } = body as Partial<GoalFormPayload>
       if (name !== undefined) goals[index].name = name
       if (description !== undefined) goals[index].description = description
       if (goal_deadline !== undefined) goals[index].goal_deadline = goal_deadline
-      return { status: 'success', Goal: goals[index] }
+      const response: ApiGoalMutationResponse<Goal> = { status: 'success', Goal: goals[index] }
+      return response
     }
 
     if (method === 'DELETE') {
       goals = goals.filter((g) => g.id !== id)
-      return { status: 'success' }
+      const response: ApiMessageResponse = { status: 'success' }
+      return response
     }
   }
 

--- a/frontend/src/api/mock/history.ts
+++ b/frontend/src/api/mock/history.ts
@@ -1,4 +1,10 @@
 // History.vue 用モックハンドラー (/history)
+//
+// StudyHistory はこの機能単独のドメイン型であり、本Issue（#64）の対象範囲（
+// api/task/user/book/goal）には含まれないため src/types/ への移設は行わない。
+// レスポンス封筒の型（ApiMockResponse）のみ共通型を参照する。
+
+import type { ApiMockResponse } from '@/types'
 
 export interface StudyHistory {
   id: number
@@ -59,7 +65,7 @@ export function handleHistory(
   method: string,
   url: string,
   body?: unknown,
-): Record<string, unknown> | null {
+): ApiMockResponse | null {
   const baseMatch = url === '/history' || url.startsWith('/history?')
 
   if (method === 'GET' && baseMatch) {

--- a/frontend/src/api/mock/index.ts
+++ b/frontend/src/api/mock/index.ts
@@ -1,10 +1,11 @@
+import type { ApiMockResponse } from '@/types'
 import { handleBooks } from './books'
 import { handleGoals } from './goals'
 import { handleHistory } from './history'
 import { handleSettings } from './settings'
 import { handleTasks } from './tasks'
 
-type Handler = (method: string, url: string, body?: unknown) => Record<string, unknown> | null
+type Handler = (method: string, url: string, body?: unknown) => ApiMockResponse | null
 
 const handlers: Handler[] = [
   handleBooks,
@@ -18,7 +19,7 @@ export function dispatch(
   method: string,
   url: string,
   body?: unknown,
-): Record<string, unknown> | null {
+): ApiMockResponse | null {
   for (const handler of handlers) {
     const result = handler(method, url, body)
     if (result !== null) return result

--- a/frontend/src/api/mock/settings.ts
+++ b/frontend/src/api/mock/settings.ts
@@ -1,12 +1,6 @@
 // Settings.vue 用モックハンドラー (/user)
 
-export interface User {
-  id: number
-  name: string
-  login_name: string
-  created_at: string
-  updated_at: string
-}
+import type { ApiItemResponse, ApiMockResponse, User, UserUpdatePayload } from '@/types'
 
 const user: User = {
   id: 1,
@@ -20,17 +14,19 @@ export function handleSettings(
   method: string,
   url: string,
   body?: unknown,
-): Record<string, unknown> | null {
+): ApiMockResponse | null {
   if (method === 'GET' && url === '/user') {
-    return { status: 'success', data: { ...user } }
+    const response: ApiItemResponse<User> = { status: 'success', data: { ...user } }
+    return response
   }
 
   if (method === 'PUT' && url === '/user') {
-    const { name, login_name } = body as { name?: string; login_name?: string }
+    const { name, login_name } = body as UserUpdatePayload
     if (name) user.name = name
     if (login_name) user.login_name = login_name
     user.updated_at = new Date().toISOString()
-    return { status: 'success', data: { ...user } }
+    const response: ApiItemResponse<User> = { status: 'success', data: { ...user } }
+    return response
   }
 
   return null

--- a/frontend/src/api/mock/tasks.ts
+++ b/frontend/src/api/mock/tasks.ts
@@ -1,22 +1,6 @@
 // TaskManager.vue 用モックハンドラー (/tasks)
 
-export interface Task {
-  id: number
-  user_id: number | null
-  parent_task_id: number | null
-  name: string
-  description: string | null
-  schedule_date: string | null
-  exec_expected_date: string | null
-  deadline: string | null
-  status: 'TODO' | 'IN_PROGRESS' | 'COMPLETED' | 'CANCELLED'
-  duration_seconds: number | null
-  category: string | null
-  comment: string | null
-  created_at: string
-  updated_at: string
-  deleted_at: string | null
-}
+import type { ApiItemResponse, ApiListResponse, ApiMessageResponse, ApiMockResponse, Task, TaskFormPayload } from '@/types'
 
 const now = new Date().toISOString()
 
@@ -51,14 +35,15 @@ export function handleTasks(
   method: string,
   url: string,
   body?: unknown,
-): Record<string, unknown> | null {
+): ApiMockResponse | null {
   if (method === 'GET' && url === '/tasks') {
-    return { status: 'success', data: [...tasks], count: tasks.length }
+    const response: ApiListResponse<Task> = { status: 'success', data: [...tasks], count: tasks.length }
+    return response
   }
 
   if (method === 'POST' && url === '/tasks') {
     const { taskTitle, taskDescription, taskStatusId, taskStartTime, taskEndTime } =
-      body as { taskTitle: string; taskDescription: string; taskStatusId?: string; taskStartTime?: string; taskEndTime?: string }
+      body as TaskFormPayload
     const task: Task = {
       id: nextId++, user_id: 1, parent_task_id: null,
       name: taskTitle, description: taskDescription ?? null,
@@ -70,7 +55,8 @@ export function handleTasks(
       created_at: now, updated_at: now, deleted_at: null,
     }
     tasks.push(task)
-    return { status: 'success', data: task }
+    const response: ApiItemResponse<Task> = { status: 'success', data: task }
+    return response
   }
 
   const idMatch = url.match(/^\/tasks\/(\d+)$/)
@@ -80,26 +66,29 @@ export function handleTasks(
     if (method === 'GET') {
       const task = tasks.find((t) => t.id === id)
       if (!task) return null
-      return { status: 'success', data: task }
+      const response: ApiItemResponse<Task> = { status: 'success', data: task }
+      return response
     }
 
     if (method === 'PUT') {
       const index = tasks.findIndex((t) => t.id === id)
       if (index === -1) return null
       const { taskTitle, taskDescription, taskStatusId, taskStartTime, taskEndTime } =
-        body as { taskTitle?: string; taskDescription?: string; taskStatusId?: string; taskStartTime?: string; taskEndTime?: string }
+        body as Partial<TaskFormPayload>
       if (taskTitle !== undefined) tasks[index].name = taskTitle
       if (taskDescription !== undefined) tasks[index].description = taskDescription
-      if (taskStatusId !== undefined) tasks[index].status = taskStatusId as Task['status']
+      if (taskStatusId !== undefined) tasks[index].status = taskStatusId
       if (taskStartTime !== undefined) tasks[index].exec_expected_date = new Date(taskStartTime).toISOString()
       if (taskEndTime !== undefined) tasks[index].deadline = new Date(taskEndTime).toISOString()
       tasks[index].updated_at = new Date().toISOString()
-      return { status: 'success', data: tasks[index] }
+      const response: ApiItemResponse<Task> = { status: 'success', data: tasks[index] }
+      return response
     }
 
     if (method === 'DELETE') {
       tasks = tasks.filter((t) => t.id !== id)
-      return { status: 'success', message: 'タスクが削除されました' }
+      const response: ApiMessageResponse = { status: 'success', message: 'タスクが削除されました' }
+      return response
     }
   }
 

--- a/frontend/src/components/Milestone.vue
+++ b/frontend/src/components/Milestone.vue
@@ -1,13 +1,7 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
 import apiClient from '../api/client'
-
-interface Goal {
-  id: number
-  name: string
-  description: string | null
-  goal_deadline: string
-}
+import type { ApiGoalMutationResponse, ApiListResponse, Goal, GoalFormPayload } from '@/types'
 
 const goals = ref<Goal[]>([])
 const isLoading = ref(false)
@@ -29,7 +23,7 @@ async function fetchGoals() {
   isLoading.value = true
   error.value = null
   try {
-    const response = await apiClient.get<{ status: string; data: Goal[] }>('/goals')
+    const response = await apiClient.get<ApiListResponse<Goal>>('/goals')
     goals.value = response.data.data
   } catch {
     error.value = 'マイルストーンの取得に失敗しました'
@@ -58,20 +52,20 @@ async function submitForm() {
   if (!form.value.name.trim() || !form.value.goal_deadline) return
   error.value = null
   try {
-    const payload = {
+    const payload: GoalFormPayload = {
       name: form.value.name.trim(),
       description: form.value.description.trim() || null,
       goal_deadline: form.value.goal_deadline,
     }
     if (editingId.value !== null) {
-      const response = await apiClient.put<{ status: string; Goal: Goal }>(
+      const response = await apiClient.put<ApiGoalMutationResponse<Goal>>(
         `/goals/${editingId.value}`,
         payload,
       )
       const idx = goals.value.findIndex((g) => g.id === editingId.value)
       if (idx !== -1) goals.value[idx] = response.data.Goal
     } else {
-      const response = await apiClient.post<{ status: string; Goal: Goal }>('/goals', payload)
+      const response = await apiClient.post<ApiGoalMutationResponse<Goal>>('/goals', payload)
       goals.value.push(response.data.Goal)
     }
     showForm.value = false

--- a/frontend/src/components/Reading.vue
+++ b/frontend/src/components/Reading.vue
@@ -1,12 +1,7 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
 import apiClient from '../api/client'
-
-interface Book {
-  id: number
-  title: string
-  description: string | null
-}
+import type { ApiBookMutationResponse, ApiListResponse, Book, BookFormPayload } from '@/types'
 
 const books = ref<Book[]>([])
 const isLoading = ref(false)
@@ -23,7 +18,7 @@ async function fetchBooks() {
   isLoading.value = true
   error.value = null
   try {
-    const response = await apiClient.get<{ status: string; data: Book[] }>('/books')
+    const response = await apiClient.get<ApiListResponse<Book>>('/books')
     books.value = response.data.data
   } catch {
     error.value = '書籍の取得に失敗しました'
@@ -40,10 +35,11 @@ async function addBook() {
   }
 
   try {
-    const response = await apiClient.post<{ status: string; book: Book }>('/books', {
+    const payload: BookFormPayload = {
       title: newTitle.value.trim(),
       description: newDescription.value.trim() || null,
-    })
+    }
+    const response = await apiClient.post<ApiBookMutationResponse<Book>>('/books', payload)
     books.value.push(response.data.book)
 
     // 成功したらフォームをリセット

--- a/frontend/src/components/Settings.vue
+++ b/frontend/src/components/Settings.vue
@@ -1,12 +1,7 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
 import apiClient from '../api/client'
-
-interface User {
-  id: number
-  name: string
-  login_name: string
-}
+import type { ApiItemResponse, User, UserUpdatePayload } from '@/types'
 
 const user = ref<User | null>(null)
 const isLoading = ref(false)
@@ -20,7 +15,7 @@ async function fetchUser() {
   isLoading.value = true
   error.value = null
   try {
-    const response = await apiClient.get<{ status: string; data: User }>('/user')
+    const response = await apiClient.get<ApiItemResponse<User>>('/user')
     user.value = response.data.data
     editName.value = user.value.name
     editLoginName.value = user.value.login_name
@@ -35,10 +30,11 @@ async function saveUser() {
   error.value = null
   saveSuccess.value = false
   try {
-    const response = await apiClient.put<{ status: string; data: User }>('/user', {
+    const payload: UserUpdatePayload = {
       name: editName.value,
       login_name: editLoginName.value,
-    })
+    }
+    const response = await apiClient.put<ApiItemResponse<User>>('/user', payload)
     user.value = response.data.data
     saveSuccess.value = true
     setTimeout(() => (saveSuccess.value = false), 3000)

--- a/frontend/src/components/TaskManager.vue
+++ b/frontend/src/components/TaskManager.vue
@@ -1,18 +1,9 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
 import apiClient from '../api/client'
+import type { ApiItemResponse, ApiListResponse, Task, TaskFormPayload, TaskStatus } from '@/types'
 
-type Status = 'TODO' | 'IN_PROGRESS' | 'COMPLETED' | 'CANCELLED'
-
-interface Task {
-  id: number
-  name: string
-  description: string | null
-  status: Status
-  exec_expected_date: string | null
-  deadline: string | null
-  category: string | null
-}
+type Status = TaskStatus
 
 const STATUS_LABELS: Record<Status, string> = {
   TODO: '未着手',
@@ -30,10 +21,10 @@ const activeStatus = ref<Status | 'ALL'>('ALL')
 
 const showForm = ref(false)
 const editingId = ref<number | null>(null)
-const form = ref({
+const form = ref<TaskFormPayload>({
   taskTitle: '',
   taskDescription: '',
-  taskStatusId: 'TODO' as Status,
+  taskStatusId: 'TODO',
   taskStartTime: '',
   taskEndTime: '',
 })
@@ -57,7 +48,7 @@ async function fetchTasks() {
   isLoading.value = true
   error.value = null
   try {
-    const response = await apiClient.get<{ status: string; data: Task[] }>('/tasks')
+    const response = await apiClient.get<ApiListResponse<Task>>('/tasks')
     tasks.value = response.data.data
   } catch {
     error.value = 'タスクの取得に失敗しました'
@@ -95,14 +86,14 @@ async function submitForm() {
   error.value = null
   try {
     if (editingId.value !== null) {
-      const response = await apiClient.put<{ status: string; data: Task }>(
+      const response = await apiClient.put<ApiItemResponse<Task>>(
         `/tasks/${editingId.value}`,
         form.value,
       )
       const idx = tasks.value.findIndex((t) => t.id === editingId.value)
       if (idx !== -1) tasks.value[idx] = response.data.data
     } else {
-      const response = await apiClient.post<{ status: string; data: Task }>('/tasks', form.value)
+      const response = await apiClient.post<ApiItemResponse<Task>>('/tasks', form.value)
       tasks.value.push(response.data.data)
     }
     showForm.value = false

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -1,0 +1,63 @@
+// APIレスポンス共通型
+//
+// 実際の封筒（レスポンス本体）は以下の形をとる。
+//   - 一覧取得: { status: 'success', data: T[], count?: number }
+//   - 単体取得・更新: { status: 'success', data: T }
+//   - 削除: { status: 'success', message?: string }
+//
+// 【既知の技術的負債】POST/PUT のペイロードキーはエンドポイントごとに不統一。
+//   - /tasks (POST/PUT): `data` キー          → ApiItemResponse<Task> と同形
+//   - /goals (POST/PUT): `Goal` キー（大文字始まり） → ApiGoalMutationResponse<Goal>
+//   - /books (POST/PUT): `book` キー（小文字）       → ApiBookMutationResponse<Book>
+// 本Issueではこの不統一を型で無理に吸収せず、実態をそのまま型として表現するに留める。
+// キーの統一は別Issueのスコープとする。
+
+export type ApiStatus = 'success'
+
+/** 一覧取得系のレスポンス封筒（例: GET /tasks, GET /goals, GET /books, GET /history） */
+export interface ApiListResponse<T> {
+  status: ApiStatus
+  data: T[]
+  count?: number
+}
+
+/** 単体取得・更新系のレスポンス封筒（例: GET /tasks/:id, PUT /tasks/:id, GET /user） */
+export interface ApiItemResponse<T> {
+  status: ApiStatus
+  data: T
+}
+
+/** 削除系など、データ本体を含まないレスポンス封筒 */
+export interface ApiMessageResponse {
+  status: ApiStatus
+  message?: string
+}
+
+/**
+ * goals の POST/PUT レスポンス封筒。
+ * 本来は `data` キーであるべきだが、実装上 `Goal`（大文字始まり）キーになっている（既知の技術的負債）。
+ */
+export interface ApiGoalMutationResponse<T> {
+  status: ApiStatus
+  Goal: T
+}
+
+/**
+ * books の POST/PUT レスポンス封筒。
+ * 本来は `data` キーであるべきだが、実装上 `book`（小文字）キーになっている（既知の技術的負債）。
+ */
+export interface ApiBookMutationResponse<T> {
+  status: ApiStatus
+  book: T
+}
+
+/**
+ * モックハンドラー（`src/api/mock/*.ts`）が返しうるレスポンス封筒の合併型。
+ * 各エンドポイントの封筒キー不統一（本ファイル冒頭のコメント参照）をそのまま型に反映している。
+ */
+export type ApiMockResponse =
+  | ApiListResponse<unknown>
+  | ApiItemResponse<unknown>
+  | ApiMessageResponse
+  | ApiGoalMutationResponse<unknown>
+  | ApiBookMutationResponse<unknown>

--- a/frontend/src/types/book.ts
+++ b/frontend/src/types/book.ts
@@ -1,0 +1,17 @@
+// 書籍型
+// Reading.vue / src/api/mock/books.ts のインライン定義を移設したもの。
+
+export interface Book {
+  id: number
+  title: string
+  description: string | null
+}
+
+/**
+ * 書籍登録・更新フォームで使用するペイロード型（POST/PUT /books のリクエストボディ）。
+ * Reading.vue のフォーム状態と、mock/books.ts のリクエストボディ取り出しに対応する。
+ */
+export interface BookFormPayload {
+  title: string
+  description: string | null
+}

--- a/frontend/src/types/goal.ts
+++ b/frontend/src/types/goal.ts
@@ -1,0 +1,19 @@
+// 目標・マイルストーン型
+// Milestone.vue / src/api/mock/goals.ts のインライン定義を移設したもの。
+
+export interface Goal {
+  id: number
+  name: string
+  description: string | null
+  goal_deadline: string
+}
+
+/**
+ * 目標作成・更新フォームで使用するペイロード型（POST/PUT /goals のリクエストボディ）。
+ * Milestone.vue のフォーム状態と、mock/goals.ts のリクエストボディ取り出しに対応する。
+ */
+export interface GoalFormPayload {
+  name: string
+  description: string | null
+  goal_deadline: string
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,0 +1,8 @@
+// src/types/ バレルエクスポート
+// `import { Task } from '@/types'` のように各ドメイン型をまとめて参照できるようにする。
+
+export * from './api'
+export * from './task'
+export * from './user'
+export * from './book'
+export * from './goal'

--- a/frontend/src/types/task.ts
+++ b/frontend/src/types/task.ts
@@ -1,0 +1,36 @@
+// タスク・サブタスク型
+// TaskManager.vue / src/api/mock/tasks.ts のインライン定義を移設したもの。
+
+/** タスクのステータス（リテラルユニオン） */
+export type TaskStatus = 'TODO' | 'IN_PROGRESS' | 'COMPLETED' | 'CANCELLED'
+
+export interface Task {
+  id: number
+  user_id: number | null
+  /** サブタスクの場合、親タスクのID。トップレベルタスクは null */
+  parent_task_id: number | null
+  name: string
+  description: string | null
+  schedule_date: string | null
+  exec_expected_date: string | null
+  deadline: string | null
+  status: TaskStatus
+  duration_seconds: number | null
+  category: string | null
+  comment: string | null
+  created_at: string
+  updated_at: string
+  deleted_at: string | null
+}
+
+/**
+ * タスク作成・更新フォームで使用するペイロード型（POST/PUT /tasks のリクエストボディ）。
+ * TaskManager.vue のフォーム状態と、mock/tasks.ts のリクエストボディ取り出しに対応する。
+ */
+export interface TaskFormPayload {
+  taskTitle: string
+  taskDescription: string
+  taskStatusId?: TaskStatus
+  taskStartTime?: string
+  taskEndTime?: string
+}

--- a/frontend/src/types/user.ts
+++ b/frontend/src/types/user.ts
@@ -1,0 +1,30 @@
+// ユーザー・認証型
+//
+// バックエンドのユーザー／認証スキーマは未確定のため、最小構成に留める。
+// 認証は Bearer トークン（localStorage の `token`）のみで、セッション情報等の型は
+// 仕様確定後に拡張する前提とする。
+//
+// Settings.vue / src/api/mock/settings.ts のインライン定義を移設したもの。
+
+export interface User {
+  id: number
+  name: string
+  login_name: string
+  created_at: string
+  updated_at: string
+}
+
+/**
+ * ユーザー設定更新フォームで使用するペイロード型（PUT /user のリクエストボディ）。
+ * Settings.vue のフォーム状態と、mock/settings.ts のリクエストボディ取り出しに対応する。
+ */
+export interface UserUpdatePayload {
+  name?: string
+  login_name?: string
+}
+
+/**
+ * 認証トークン（localStorage の `token`）を表す最小型。
+ * バックエンドの認証仕様確定後、有効期限やリフレッシュトークン等を含む型へ拡張する想定。
+ */
+export type AuthToken = string


### PR DESCRIPTION
## Summary
- `frontend/src/types/` を新設（`api.ts`, `task.ts`, `goal.ts`, `book.ts`, `user.ts`, `index.ts`）
- コンポーネント・モックAPIに散在していた `Task` / `Goal` / `Book` のインライン型定義を集約し、既存コードから `@/types` を参照させる形に置換
- 封筒（APIレスポンス）キーの不統一（tasks→`data`, goals→`Goal`, books→`book`）は型で無理に統一せず、実態通りコメント付きで表現（統一自体は別スコープ）
- `user.ts` はバックエンド仕様未確定のため最小構成

Closes #64

## Out of scope
- 既存any型の網羅的な置き換え（#20）
- Piniaストア実装（#65）
- APIレスポンス封筒キーの統一

## Test plan
- [x] `npm run type-check`（vue-tsc --build）: エラー0
- [x] `npm run lint`（eslint . --fix）: エラー/警告0
- [x] `npm run test:unit`（vitest）: リポジトリに既存テストファイルが存在せず実行対象なし（本PR起因ではない既存状態）

🤖 Generated with [Claude Code](https://claude.com/claude-code)