### PR TITLE
[設定] 環境変数名をVITE_API_BASE_URLに統一する

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,7 +35,7 @@ BACKEND_USER_ID=study_user
 BACKEND_VOLUME_1=./backend
 
 # frontend
-FRONTEND_VITE_API_URL=http://localhost:3000
+VITE_API_BASE_URL=http://localhost:3000
 FRONTEND_PORT=5173
 FRONTEND_HOST=0.0.0.0
 FRONTEND_VOLUME_1=./frontend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,7 +77,7 @@ services:
     ports:
       - "${FRONTEND_PORT}:${FRONTEND_PORT}"
     environment:
-      FRONTEND_VITE_API_URL: ${FRONTEND_VITE_API_URL}
+      VITE_API_BASE_URL: ${VITE_API_BASE_URL}
       FRONTEND_HOST: ${FRONTEND_HOST}
       CHOKIDAR_USEPOLLING: "true"
     depends_on:


### PR DESCRIPTION
## Summary
- `docker-compose.yml` の frontend service 環境変数キーを `FRONTEND_VITE_API_URL` から `VITE_API_BASE_URL` に変更（展開元変数名も同時に統一）
- ルート `.env.example` の該当キーも `VITE_API_BASE_URL` に統一
- フロントエンド（`frontend/src/api/client.ts`）は元々 `VITE_API_BASE_URL` を参照しており無変更

Closes #62

## Test plan
- [x] `grep -rn "FRONTEND_VITE_API_URL"` で残存0件を確認
- [x] `docker compose --profile full config` で構文エラーなし、`VITE_API_BASE_URL` が正しく解決されることを確認
- [ ] レビュー環境で `docker compose --profile full up` を実行し、frontendがクラッシュせず起動することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)